### PR TITLE
Patch version bump - non functional change.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "security.txt",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Cross-platform browser extension for security.txt and humans.txt files.",
   "homepage": "https://www.harmless.systems/products/security-txt.html",
   "main": "Gruntfile.js",


### PR DESCRIPTION
Not able to overwrite the previously uploaded (but unpublished)
extension in the Firefox store so a pointless patch bump is necessary.